### PR TITLE
Revert "add contributors page to About"

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -192,11 +192,8 @@ gtag('config', 'G-DMTGHZ2N2J', { 'anonymize_ip': true});
 <h2 class="anchored" data-anchor-id="next-steps">Next Steps</h2>
 <p>We are exploring adding RPV data for all the cities, towns, and villages in the U.S. If this would be useful to you, please contact us at <a href="mailto:elc@law.harvard.edu">elc@law.harvard.edu</a> to let us know.</p>
 <p>If there are other related products that would be useful in your efforts to enfranchise communities of color at the local level, please also reach out with a description of those products <a href="mailto:elc@law.harvard.edu">elc@law.harvard.edu</a>.</p>
-</section>
 
-<section id="Contributors" class="level2">
-  <h2 class="anchored" data-anchor-id="next-steps">Contributors<a class="anchorjs-link " aria-label="Anchor" data-anchorjs-icon="" href="#collaborators" style="font: 1em / 1 anchorjs-icons; margin-left: 0.1875em; padding-right: 0.1875em; padding-left: 0.1875em;"></a></h2>
-  <p>RPV Near Me was built by multiple key contributors, including <a href="https://christophertkenny.com" target="_blank">Chris Kenny</a>, <a href="https://sites.google.com/g.harvard.edu/dagonel/" target="_blank">Angelo Dagonel</a>, and Alex Fung.</p>    
+
 </section>
 </section>
 


### PR DESCRIPTION
Reverts electionlawclinic/rpvnearme#2, so I can edit qmd file instead of html